### PR TITLE
Fix the cache issue

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { Fold } from "./Fold";
 const db = new DB();
 
 export default async function Page() {
-  const folds = await db.getFolds();
+  const folds = await db.getFoldSample();
   const max = Math.max(...folds);
   const challenge = crypto.randomBytes(50).toString("base64");
   const token = createToken(challenge);
@@ -46,3 +46,4 @@ export default async function Page() {
 }
 
 export const dynamic = "force-dynamic";
+export const revalidate = 60;

--- a/util.ts
+++ b/util.ts
@@ -53,7 +53,7 @@ export class DB {
     }
     return folds;
   }
-  async getRandomUniqFolds() {
+  async getFoldSample() {
     const SAMPLE_SIZE = 1000;
     const folds = await this.getFolds();
     const uniqFolds = new Set<number>();
@@ -63,7 +63,8 @@ export class DB {
     }
 
     while (uniqFolds.size < SAMPLE_SIZE) {
-      uniqFolds.add(folds[Math.floor(Math.random() * folds.length)]);
+      const randomIndex = Math.floor(Math.random() * folds.length);
+      uniqFolds.add(folds[randomIndex]);
     }
 
     return Array.from(uniqFolds);


### PR DESCRIPTION
Next was caching so the same results were being shown, unless you did a hard browser refresh. Probably wasn't noticed by any new visitors to the site — but repeat visitors (like me) would just see like 3 lines each time.

This fixes that, and also pulls the 1000-fold sample.